### PR TITLE
feat: Add GitHub Action for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch if not main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Specify your project's Node.js version
+
+      - name: Install dependencies
+        run: npm install # Or yarn install if your project uses Yarn
+
+      - name: Build application
+        run: npm run build # Or yarn build
+        # Ensure this command outputs to a 'build' or 'dist' folder,
+        # or update the deploy step's 'publish_dir' accordingly.
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./build # Adjust if your build output is in a different directory (e.g., ./dist)
+          # Optional: if your site is not at the root of the gh-pages branch (e.g., username.github.io/repo-name)
+          # then you might need to set the base path in your React app's package.json:
+          # "homepage": "http://username.github.io/repo-name"
+          # and configure your router accordingly if using client-side routing.


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`.github/workflows/deploy-gh-pages.yml`).

The workflow is configured to:
- Trigger on pushes to the `main` branch.
- Check out the repository code.
- Set up Node.js (version 20).
- Install project dependencies using `npm install`.
- Build the React application using `npm run build`.
- Deploy the contents of the `./build` directory to the `gh-pages` branch using the `peaceiris/actions-gh-pages@v4` action.

This automates the deployment process to GitHub Pages whenever changes are merged into the main branch.