### PR TITLE
fix: Grant write permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Updated the `.github/workflows/deploy-gh-pages.yml` workflow to grant `contents: write` permission to the `GITHUB_TOKEN`. This is required for the `peaceiris/actions-gh-pages` action to successfully push the build output to the `gh-pages` branch.