### PR TITLE
fix: Ensure dark mode applies visually throughout the app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,11 +150,11 @@ function App() {
       }
 
   return (
-    <div className="p-6">
-                <h1 className="text-2xl font-semibold mb-6">Keyboard Shortcut Editor</h1>
+    <div className="p-6 bg-background text-foreground">
+                <h1 className="text-2xl font-semibold mb-6 text-foreground">Keyboard Shortcut Editor</h1>
     
-                <div className="bg-white rounded-lg shadow-md p-6 mb-8">
-                    <h2 className="text-xl font-semibold mb-4">
+                <div className="bg-card text-card-foreground rounded-lg shadow-md p-6 mb-8">
+                    <h2 className="text-xl font-semibold mb-4 text-card-foreground">
                         {isPreview ? title : "Table Title"}
                     </h2>
                     {!isPreview && (


### PR DESCRIPTION
The dark mode toggle was correctly adding the '.dark' class to the HTML element, but the application was not visually updating because key container elements in `App.tsx` had hardcoded background colors (e.g., 'bg-white').

This commit updates `App.tsx` to use theme-aware Tailwind utility classes for backgrounds and text colors:
- The main application container now uses `bg-background` and `text-foreground`.
- The card-like content container now uses `bg-card` and `text-card-foreground`.
- Headings `h1` and `h2` now also use `text-foreground` and `text-card-foreground` respectively.

These changes ensure that the application's main layout and text elements correctly adapt to the selected theme (light or dark) based on the CSS variables defined in `src/app/globals.css`.