### PR TITLE
fix: Configure Tailwind CSS to use CSS variables for theming

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,48 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}", // Important for Shadcn
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        border: "oklch(var(--border) / <alpha-value>)",
+        input: "oklch(var(--input) / <alpha-value>)",
+        ring: "oklch(var(--ring) / <alpha-value>)",
+        background: "oklch(var(--background) / <alpha-value>)",
+        foreground: "oklch(var(--foreground) / <alpha-value>)",
+        primary: {
+          DEFAULT: "oklch(var(--primary) / <alpha-value>)",
+          foreground: "oklch(var(--primary-foreground) / <alpha-value>)",
+        },
+        secondary: {
+          DEFAULT: "oklch(var(--secondary) / <alpha-value>)",
+          foreground: "oklch(var(--secondary-foreground) / <alpha-value>)",
+        },
+        destructive: {
+          DEFAULT: "oklch(var(--destructive) / <alpha-value>)",
+          foreground: "oklch(var(--destructive-foreground) / <alpha-value>)", // Assuming you might add --destructive-foreground later
+        },
+        muted: {
+          DEFAULT: "oklch(var(--muted) / <alpha-value>)",
+          foreground: "oklch(var(--muted-foreground) / <alpha-value>)",
+        },
+        accent: {
+          DEFAULT: "oklch(var(--accent) / <alpha-value>)",
+          foreground: "oklch(var(--accent-foreground) / <alpha-value>)",
+        },
+        popover: {
+          DEFAULT: "oklch(var(--popover) / <alpha-value>)",
+          foreground: "oklch(var(--popover-foreground) / <alpha-value>)",
+        },
+        card: {
+          DEFAULT: "oklch(var(--card) / <alpha-value>)",
+          foreground: "oklch(var(--card-foreground) / <alpha-value>)",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
   },
   plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
I updated `tailwind.config.js` to correctly map theme color names (e.g., background, foreground, card, primary) and border radius values to the CSS variables defined in `src/app/globals.css`.

This was a necessary step for Tailwind's utility classes (like `bg-background`, `text-foreground`) to correctly apply the application's theme, enabling proper visual switching between light and dark modes.

The `theme.extend.colors` and `theme.extend.borderRadius` sections were populated with mappings using the `oklch(var(--variable) / <alpha-value>)` syntax for colors and `var(--radius)` for border radius, following standard Shadcn UI and Tailwind CSS variable conventions.