### PR TITLE
Okay, here's how I've updated your code:

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,38 +8,38 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        border: "oklch(var(--border) / <alpha-value>)",
-        input: "oklch(var(--input) / <alpha-value>)",
-        ring: "oklch(var(--ring) / <alpha-value>)",
-        background: "oklch(var(--background) / <alpha-value>)",
-        foreground: "oklch(var(--foreground) / <alpha-value>)",
+        border: "var(--border)",
+        input: "var(--input)",
+        ring: "var(--ring)",
+        background: "var(--background)",
+        foreground: "var(--foreground)",
         primary: {
-          DEFAULT: "oklch(var(--primary) / <alpha-value>)",
-          foreground: "oklch(var(--primary-foreground) / <alpha-value>)",
+          DEFAULT: "var(--primary)",
+          foreground: "var(--primary-foreground)",
         },
         secondary: {
-          DEFAULT: "oklch(var(--secondary) / <alpha-value>)",
-          foreground: "oklch(var(--secondary-foreground) / <alpha-value>)",
+          DEFAULT: "var(--secondary)",
+          foreground: "var(--secondary-foreground)",
         },
         destructive: {
-          DEFAULT: "oklch(var(--destructive) / <alpha-value>)",
-          foreground: "oklch(var(--destructive-foreground) / <alpha-value>)", // Assuming you might add --destructive-foreground later
+          DEFAULT: "var(--destructive)",
+          // foreground: "var(--destructive-foreground)", // Removed as per subtask description
         },
         muted: {
-          DEFAULT: "oklch(var(--muted) / <alpha-value>)",
-          foreground: "oklch(var(--muted-foreground) / <alpha-value>)",
+          DEFAULT: "var(--muted)",
+          foreground: "var(--muted-foreground)",
         },
         accent: {
-          DEFAULT: "oklch(var(--accent) / <alpha-value>)",
-          foreground: "oklch(var(--accent-foreground) / <alpha-value>)",
+          DEFAULT: "var(--accent)",
+          foreground: "var(--accent-foreground)",
         },
         popover: {
-          DEFAULT: "oklch(var(--popover) / <alpha-value>)",
-          foreground: "oklch(var(--popover-foreground) / <alpha-value>)",
+          DEFAULT: "var(--popover)",
+          foreground: "var(--popover-foreground)",
         },
         card: {
-          DEFAULT: "oklch(var(--card) / <alpha-value>)",
-          foreground: "oklch(var(--card-foreground) / <alpha-value>)",
+          DEFAULT: "var(--card)",
+          foreground: "var(--card-foreground)",
         },
       },
       borderRadius: {


### PR DESCRIPTION
I've corrected the Tailwind color mappings to prevent nested `oklch()` functions.

I updated `tailwind.config.js` to use direct CSS variable references (e.g., `var(--card)`) for color definitions. This is for situations where the CSS variable itself already contains the full color function (e.g., `oklch(...)`).

This change fixes a problem where the previous setup, like `oklch(var(--card) / <alpha-value>)`, would create invalid nested `oklch(oklch(...))` CSS if `var(--card)` expanded to an `oklch()` string.

I also removed the `destructive.foreground` mapping because the corresponding `--destructive-foreground` CSS variable wasn't defined in `globals.css`.

These adjustments ensure that Tailwind generates valid CSS for theming and that dark/light mode styles apply correctly based on the variables in `globals.css`.